### PR TITLE
add unambigious license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ All of these acknowledgements are mentioned in code comments, but I wanted too a
 
 ## License
 
+[![GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-blue.svg)](https://spdx.org/licenses/GPL-3.0-only.html)
+
 Equalizer314 is released under the **GNU General Public License v3.0**. See [LICENSE](LICENSE) for the full text.
 
 You are free to use, modify, and redistribute this software under the terms of the GPL v3. If you distribute a modified version, you must release the source under the same license.


### PR DESCRIPTION
* License: GPL-3.0-only https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/com.bearinmind.equalizer314.yml 
* this badge adds unambigious license badge with spdx license text
* inspiration: 
  * For Clarity's Sake, Please Don't Say "Licensed under GNU GPL 2"! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html